### PR TITLE
Add alt-text language selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
 # PDF Alt-Text Generator
 
 Streamlit app to generate alt-text for images in PDFs using OpenAI or Groq vision models.
+The sidebar allows selecting the language for the generated alt-text (English, Dutch, Spanish, French or German).

--- a/app.py
+++ b/app.py
@@ -39,6 +39,11 @@ with st.sidebar:
     selected_model = st.radio("Vision Model", ["OpenAI", "Groq"])
     openai_key = st.text_input("OpenAI API Key", type="password")
     groq_key = st.text_input("Groq API Key", type="password")
+    language = st.selectbox(
+        "Alt-Text Language",
+        ["English", "Dutch", "Spanish", "French", "German"],
+        index=0,
+    )
     alt_lines = st.number_input(
         " Number of Alt-Text Lines",
         min_value=1,
@@ -86,7 +91,8 @@ if uploaded_file:
                     openai_key,
                     groq_key,
                     is_logo=is_logo,
-                    alt_line_count=alt_lines
+                    alt_line_count=alt_lines,
+                    language=language,
                 )
 
                 label = label_output(page_num, idx + 1, alt_text)

--- a/utils/alt_text_generator.py
+++ b/utils/alt_text_generator.py
@@ -47,7 +47,8 @@ def generate_alt_text(
     openai_key: str,
     groq_key: str,
     is_logo: bool = False,
-    alt_line_count: int = 2
+    alt_line_count: int = 2,
+    language: str = "English"
 ) -> str:
     """
     Generate alt-text using the selected vision model.
@@ -59,6 +60,7 @@ def generate_alt_text(
         groq_key: Groq API key
         is_logo: Whether the image is a company logo
         alt_line_count: Max number of lines for alt-text
+        language: Desired language for the alt-text
 
     Returns:
         Alt-text string
@@ -66,7 +68,10 @@ def generate_alt_text(
     if is_logo:
         return "Company logo."
 
-    prompt = f"Generate a brief alt-text for this image within {alt_line_count} line(s), suitable for screen readers."
+    prompt = (
+        f"Generate a brief alt-text in {language} for this image within "
+        f"{alt_line_count} line(s), suitable for screen readers."
+    )
     b64_image = encode_image_to_base64(image)
 
     try:


### PR DESCRIPTION
## Summary
- allow users to choose alt‑text language in sidebar
- pass language choice to alt-text generation prompt
- document the new language feature

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6842c86791708329bfa10c5c881bfaf0